### PR TITLE
Markerのinteractiveオプションを設定可能にする

### DIFF
--- a/lib/TheMap.jsx
+++ b/lib/TheMap.jsx
@@ -239,6 +239,7 @@ class TheMap extends React.Component {
     const {
       draggable = false,
       height = ThemeValues.tappableHeight,
+      interactive = true,
       lat,
       lng,
       node,
@@ -252,6 +253,7 @@ class TheMap extends React.Component {
         className: 'the-map-marker-div-icon',
         iconSize: L.point(width, height),
       }),
+      interactive,
       riseOnHover,
     })
     marker.addTo(map)


### PR DESCRIPTION
`TheMap`のpropsに`freezed`を指定している場合にも`Marker`の`pointer-events`が有効なままであるため、
地図上のマーカーを掴んでドラッグすると地図全体が動いてしまいます。
`Marker`の`interactive`オプションを設定できるようにして、この場合に(`interactive = false`に設定することで）地図を完全に動かせないようにします。